### PR TITLE
Update boost to 1.90.0

### DIFF
--- a/metadata/boost.json
+++ b/metadata/boost.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
   "modification_status": "clean",
-  "release": "6",
-  "sha": "34c9070e6ab76c6300d5423e0e939c84ba057478",
+  "release": "7",
+  "sha": "7d6a68d9597c2fed2632dc1d9c4b7c03b8fe3937",
   "source": "https://src.fedoraproject.org/rpms/boost.git",
   "version": "1.90.0"
 }

--- a/rpms/boost/boost.spec
+++ b/rpms/boost/boost.spec
@@ -52,7 +52,7 @@ Name: boost
 %global real_name boost
 Summary: The free peer-reviewed portable C++ source libraries
 Version: 1.90.0
-Release: 6%{?dist}
+Release: 7%{?dist}
 License: BSL-1.0 AND MIT AND Python-2.0.1
 
 # Replace each . with _ in %%{version}
@@ -141,6 +141,7 @@ BuildRequires: libquadmath-devel
 %endif
 BuildRequires: bison
 BuildRequires: libzstd-devel
+BuildRequires: which
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1541035
 Patch0: boost-1.81.0-build-optflags.patch
@@ -191,6 +192,7 @@ variables.
 
 %package charconv
 Summary: Run-time component of boost charconv library
+License: BSL-1.0 AND (BSL-1.0 OR Apache-2.0 WITH LLVM-exception)
 
 %description charconv
 
@@ -199,6 +201,7 @@ in C++11.
 
 %package chrono
 Summary: Run-time component of boost chrono library
+License: BSL-1.0 AND (MIT OR NCSA)
 Obsoletes: boost-system < 1.90.0
 Conflicts: boost-system < 1.90.0
 
@@ -293,6 +296,7 @@ directories.
 
 %package graph
 Summary: Run-time component of boost graph library
+License: BSL-1.0 AND (BSL-1.0 OR MIT)
 Requires: %{name}-regex%{?_isa} = %{version}-%{release}
 
 %description graph
@@ -311,6 +315,7 @@ stream buffers and i/o filters.
 
 %package json
 Summary: Run-time component of boost json library
+License: BSL-1.0 OR Apache-2.0
 Requires: %{name}-container%{?_isa} = %{version}-%{release}
 
 %description json
@@ -446,6 +451,7 @@ program execution monitoring.
 
 %package thread
 Summary: Run-time component of boost thread library
+License: BSL-1.0 AND (MIT OR NCSA)
 Obsoletes: boost-system < 1.90.0
 Conflicts: boost-system < 1.90.0
 
@@ -505,6 +511,7 @@ preprocessor functionality.
 
 %package devel
 Summary: The Boost C++ headers and shared development libraries
+License: BSL-1.0 AND MIT AND (MIT OR NCSA) AND (BSL-1.0 OR MIT) AND HPND-sell-variant AND Zlib AND Apache-2.0 AND (BSL-1.0 OR Apache-2.0) AND (BSL-1.0 OR Apache-2.0 WITH LLVM-exception)
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: libicu-devel%{?_isa}
 %if %{with quadmath}
@@ -1365,6 +1372,11 @@ fi
 %{_mandir}/man1/b2.1*
 
 %changelog
+* Thu Mar 19 2026 Jonathan Wakely <jwakely@fedoraproject.org> - 1.90.0-7
+- Add workaround for failing regex tests (#2430541)
+- Add BR:which as needed by the bootstrap.sh script
+- Add additional SPDX tags
+
 * Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 1.90.0-6
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
 

--- a/rpms/boost/gating.yaml
+++ b/rpms/boost/gating.yaml
@@ -7,13 +7,8 @@ rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
 --- !Policy
 product_versions:
-  - rhel-8
+  - rhel-*
 decision_context: osci_compose_gate
 rules:
-  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.tier1-gating.functional}
---- !Policy
-product_versions:
-  - rhel-9
-decision_context: osci_compose_gate
-rules:
-  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.tier1-gating.functional}
+  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.gate-build-fast-lane.functional}
+  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.gate-build-slow-lane.functional}

--- a/rpms/boost/tests/boost-testsuite-sanity/runtest.sh
+++ b/rpms/boost/tests/boost-testsuite-sanity/runtest.sh
@@ -74,6 +74,9 @@ rlJournalStart
     while read test_path; do
       if [ -f $BuildDir/libs/$test_path/test/Jamfile* ]; then
         rlRun "cd $BuildDir/libs/$test_path/test"
+        if [ "$test_path" = regex ]; then
+          rlRun "[ -e ../include ] || ln -s ../../ ../include"
+        fi
         rlRun "su -c '/usr/bin/b2 -d1 --build-dir=$TmpDir/test-build &>>$TmpDir/testsuite.log' $BUILD_USER"
         rm -fr $TmpDir/test-build
       else


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: boost
- **Version**: 1.90.0 → 1.90.0
- **Release**: 7
- **Upstream SHA**: `7d6a68d9597c`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/boost.git

Automatically synced from Fedora dist-git by Factory.