### PR TITLE
Update dnf5 to 5.4.0.0

### DIFF
--- a/metadata/dnf5.json
+++ b/metadata/dnf5.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
   "modification_status": "clean",
-  "release": "4",
-  "sha": "422be58b9c4f78ff375093753c2f744b166e4b0d",
+  "release": "5",
+  "sha": "623b0171736bcf1a2e9be0cfa217a52c9ebd4e10",
   "source": "https://src.fedoraproject.org/rpms/dnf5.git",
   "version": "5.4.0.0"
 }

--- a/rpms/dnf5/0004-libdnf5-cli-handle-C-or-POSIX-locale-gracefully-in-p.patch
+++ b/rpms/dnf5/0004-libdnf5-cli-handle-C-or-POSIX-locale-gracefully-in-p.patch
@@ -1,0 +1,146 @@
+From 39347c2ca8482b5999fabac042318ba9db65ca12 Mon Sep 17 00:00:00 2001
+From: Kan-Ru Chen <kanru@kanru.info>
+Date: Sun, 1 Mar 2026 17:29:30 +0900
+Subject: [PATCH] libdnf5-cli: handle C or POSIX locale gracefully in
+ progressbar width calculation
+
+Upstream commit: 7b137b9148ec9f025162bbfe817de1a32830fc3d
+
+Correctly detect error result from the mbrtowc() function and return early.
+Update the test to cover both C.UTF-8 and C (POSIX) locale.
+
+Fixes: #2553
+Signed-off-by: Kan-Ru Chen <kanru@kanru.info>
+Petr Pisar: Ported to 5.4.0.0.
+---
+ libdnf5-cli/progressbar/progress_bar.cpp          |  4 +++-
+ test/libdnf5-cli/CMakeLists.txt                   | 12 +++++++++++-
+ test/libdnf5-cli/test_progressbar.cpp             | 15 +++++++++++++++
+ test/libdnf5-cli/test_progressbar.hpp             |  2 ++
+ test/libdnf5-cli/test_progressbar_interactive.cpp |  8 +++++---
+ 5 files changed, 36 insertions(+), 5 deletions(-)
+
+diff --git a/libdnf5-cli/progressbar/progress_bar.cpp b/libdnf5-cli/progressbar/progress_bar.cpp
+index 6656769..54506d4 100644
+--- a/libdnf5-cli/progressbar/progress_bar.cpp
++++ b/libdnf5-cli/progressbar/progress_bar.cpp
+@@ -98,7 +98,9 @@ const ProgressBar::Impl::MessageMetrics & ProgressBar::Impl::get_message_metrics
+         // calculate the display width of the character
+         wchar_t wc;
+         auto bytes_consumed = std::mbrtowc(&wc, message.data(), message.size(), &mbstate);
+-        if (bytes_consumed <= 0) {
++        // mbrtowc returns 0 if a null wide character was found.
++        // it returns (size_t)-1 or (size_t)-2 on invalid or incomplete wide character.
++        if (bytes_consumed == 0 || bytes_consumed >= SIZE_MAX-1) {
+             break;
+         }
+         auto char_width = static_cast<std::size_t>(wcwidth(wc));
+diff --git a/test/libdnf5-cli/CMakeLists.txt b/test/libdnf5-cli/CMakeLists.txt
+index 18d99d6..6251e02 100644
+--- a/test/libdnf5-cli/CMakeLists.txt
++++ b/test/libdnf5-cli/CMakeLists.txt
+@@ -19,4 +19,14 @@ target_link_directories(run_tests_cli PRIVATE ${CMAKE_BINARY_DIR}/libdnf5)
+ target_link_libraries(run_tests_cli PRIVATE stdc++ libdnf5 libdnf5-cli test_shared)
+ 
+ 
+-add_test(NAME test_libdnf_cli COMMAND run_tests_cli)
++add_test(NAME test_libdnf_cli_C_UTF8 COMMAND run_tests_cli)
++set_tests_properties(test_libdnf_cli_C_UTF8 PROPERTIES
++    RUN_SERIAL TRUE
++    ENVIRONMENT "LC_ALL=C.UTF-8"
++)
++
++add_test(NAME test_libdnf_cli_C COMMAND run_tests_cli)
++set_tests_properties(test_libdnf_cli_C PROPERTIES
++     RUN_SERIAL TRUE
++     ENVIRONMENT "LC_ALL=C"
++ )
+diff --git a/test/libdnf5-cli/test_progressbar.cpp b/test/libdnf5-cli/test_progressbar.cpp
+index 4f094da..948bf2e 100644
+--- a/test/libdnf5-cli/test_progressbar.cpp
++++ b/test/libdnf5-cli/test_progressbar.cpp
+@@ -24,6 +24,8 @@
+ 
+ #include <libdnf5-cli/progressbar/download_progress_bar.hpp>
+ #include <libdnf5-cli/progressbar/multi_progress_bar.hpp>
++#include <clocale>
++#include <cstring>
+ 
+ 
+ CPPUNIT_TEST_SUITE_REGISTRATION(ProgressbarTest);
+@@ -33,6 +35,9 @@ void ProgressbarTest::setUp() {
+     setenv("DNF5_FORCE_INTERACTIVE", "0", 1);
+     // Force columns to 70 to make output independ of where it is run
+     setenv("FORCE_COLUMNS", "70", 1);
++    // Wide characters do not work at all until we set locales in the code
++    // Different locale variants are parameterized in ctest
++    setlocale(LC_ALL, "");
+ }
+ 
+ void ProgressbarTest::tearDown() {
+@@ -40,6 +45,16 @@ void ProgressbarTest::tearDown() {
+     unsetenv("FORCE_COLUMNS");
+ }
+ 
++void ProgressbarTest::test_progress_bar_multi_byte_character() {
++    auto progress_bar = std::make_unique<libdnf5::cli::progressbar::DownloadProgressBar>(10, "test");
++    progress_bar->set_ticks(4);
++    progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);
++    progress_bar->add_message(libdnf5::cli::progressbar::MessageType::WARNING, "Created symlink '/etc/systemd/user/sockets.target.wants/pipewire.socket' \342\206\222 '/usr/lib/systemd/user/pipewire.socket'.");
++    auto num_lines = progress_bar->calculate_messages_terminal_lines(106);
++    auto expected = strcmp(setlocale(LC_ALL, NULL), "C") == 0 ? 1UL : 2UL;
++    CPPUNIT_ASSERT_EQUAL(expected, num_lines);
++}
++
+ void ProgressbarTest::test_download_progress_bar() {
+     // In non interactive mode download progress bar is printed only when finished.
+ 
+diff --git a/test/libdnf5-cli/test_progressbar.hpp b/test/libdnf5-cli/test_progressbar.hpp
+index 3b831f8..700e841 100644
+--- a/test/libdnf5-cli/test_progressbar.hpp
++++ b/test/libdnf5-cli/test_progressbar.hpp
+@@ -27,6 +27,7 @@
+ class ProgressbarTest : public CppUnit::TestCase {
+     CPPUNIT_TEST_SUITE(ProgressbarTest);
+ 
++    CPPUNIT_TEST(test_progress_bar_multi_byte_character);
+     CPPUNIT_TEST(test_download_progress_bar);
+     CPPUNIT_TEST(test_multi_progress_bar);
+     CPPUNIT_TEST(test_multi_progress_bar_unfinished);
+@@ -37,6 +38,7 @@ public:
+     void setUp() override;
+     void tearDown() override;
+ 
++    void test_progress_bar_multi_byte_character();
+     void test_download_progress_bar();
+     void test_multi_progress_bar();
+     void test_multi_progress_bar_unfinished();
+diff --git a/test/libdnf5-cli/test_progressbar_interactive.cpp b/test/libdnf5-cli/test_progressbar_interactive.cpp
+index 760bb01..515bc76 100644
+--- a/test/libdnf5-cli/test_progressbar_interactive.cpp
++++ b/test/libdnf5-cli/test_progressbar_interactive.cpp
+@@ -152,7 +152,8 @@ void ProgressbarInteractiveTest::setUp() {
+     // Force columns to 70 to make output independ of where it is run
+     setenv("FORCE_COLUMNS", "70", 1);
+     // Wide characters do not work at all until we set locales in the code
+-    setlocale(LC_ALL, "C.UTF-8");
++    // Different locale variants are parameterized in ctest
++    setlocale(LC_ALL, "");
+ }
+ 
+ void ProgressbarInteractiveTest::tearDown() {
+@@ -314,8 +315,9 @@ void ProgressbarInteractiveTest::test_download_progress_bar_with_long_messages()
+         download_progress_bar_raw->pop_message();
+         oss << multi_progress_bar;
+         expected = "\\[1/1\\] test                     40% | ????? ??B\\/s |   4.0   B | ???????\n";
+-        // two "cursor up" lines expected
+-        CPPUNIT_ASSERT_EQUAL(2, count_cursor_up_lines(oss.str()));
++        // locale dependent
++        auto expected_lines = strcmp(setlocale(LC_ALL, NULL), "C") == 0 ? 1 : 2;
++        CPPUNIT_ASSERT_EQUAL(expected_lines, count_cursor_up_lines(oss.str()));
+     }
+ }
+ 
+-- 
+2.53.0
+

--- a/rpms/dnf5/0005-tests-Fix-a-type-mismatch-in-libdnf5-cli-test_progre.patch
+++ b/rpms/dnf5/0005-tests-Fix-a-type-mismatch-in-libdnf5-cli-test_progre.patch
@@ -1,0 +1,61 @@
+From 1f121caf2772127b40c004b1fd5219626d0338c6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Tue, 17 Mar 2026 11:01:34 +0100
+Subject: [PATCH] tests: Fix a type mismatch in libdnf5-cli/test_progressbar
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Upstream commit: 63b34412da9b3239c1296d37f8b22d276ced452d
+
+Building tests on i686 architecture failed like this:
+
+    In file included from /usr/include/cppunit/TestCase.h:6,
+		     from /builddir/build/BUILD/dnf5-5.4.0.0-build/dnf5-5.4.0.0/test/libdnf5-cli/test_progressbar.hpp:24,
+		     from /builddir/build/BUILD/dnf5-5.4.0.0-build/dnf5-5.4.0.0/test/libdnf5-cli/test_progressbar.cpp:21:
+    /builddir/build/BUILD/dnf5-5.4.0.0-build/dnf5-5.4.0.0/test/libdnf5-cli/test_progressbar.cpp: In member function ‘void ProgressbarTest::test_progress_bar_multi_byte_character()’:
+    /builddir/build/BUILD/dnf5-5.4.0.0-build/dnf5-5.4.0.0/test/libdnf5-cli/test_progressbar.cpp:55:5: error: no matching function for call to ‘assertEquals(long unsigned int&, unsigned int&, CppUnit::SourceLine, const char [1])’
+       55 |     CPPUNIT_ASSERT_EQUAL(expected, num_lines);
+	  |     ^
+      • there is 1 candidate
+	• candidate 1: ‘template<class T> void CppUnit::assertEquals(const T&, const T&, SourceLine, const std::string&)’
+	  /usr/include/cppunit/TestAssert.h:161:6:
+	    161 | void assertEquals( const T& expected,
+		|      ^~~~~~~~~~~~
+	  • template argument deduction/substitution failed:
+	    •   deduced conflicting types for parameter ‘const T’ (‘long unsigned int’ and ‘unsigned int’)
+	      /builddir/build/BUILD/dnf5-5.4.0.0-build/dnf5-5.4.0.0/test/libdnf5-cli/test_progressbar.cpp:55:5:
+		 55 |     CPPUNIT_ASSERT_EQUAL(expected, num_lines);
+		    |     ^
+
+The cause was a comparison between two variables of different types,
+size_t and unsigned long int, that have a different rank on 32-bit
+platforms, leading to a template argument mismatch.
+
+This flaw was introduced in commit
+7b137b9148ec9f025162bbfe817de1a32830fc3d ("libdnf5-cli: handle C or
+POSIX locale gracefully in progressbar width calculation").
+
+This patch fixes it.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=2443774
+---
+ test/libdnf5-cli/test_progressbar.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/libdnf5-cli/test_progressbar.cpp b/test/libdnf5-cli/test_progressbar.cpp
+index 948bf2e..88fec36 100644
+--- a/test/libdnf5-cli/test_progressbar.cpp
++++ b/test/libdnf5-cli/test_progressbar.cpp
+@@ -51,7 +51,7 @@ void ProgressbarTest::test_progress_bar_multi_byte_character() {
+     progress_bar->set_state(libdnf5::cli::progressbar::ProgressBarState::STARTED);
+     progress_bar->add_message(libdnf5::cli::progressbar::MessageType::WARNING, "Created symlink '/etc/systemd/user/sockets.target.wants/pipewire.socket' \342\206\222 '/usr/lib/systemd/user/pipewire.socket'.");
+     auto num_lines = progress_bar->calculate_messages_terminal_lines(106);
+-    auto expected = strcmp(setlocale(LC_ALL, NULL), "C") == 0 ? 1UL : 2UL;
++    std::size_t expected = strcmp(setlocale(LC_ALL, NULL), "C") == 0 ? 1U : 2U;
+     CPPUNIT_ASSERT_EQUAL(expected, num_lines);
+ }
+ 
+-- 
+2.53.0
+

--- a/rpms/dnf5/dnf5.rpmlintrc
+++ b/rpms/dnf5/dnf5.rpmlintrc
@@ -1,1 +1,2 @@
-addFilter('spelling-error \(\'changelog|copr|cron|modulemd|repoclosure|reposync\'')
+addFilter('non-conffile-in-etc /etc/dnf/dnf5-aliases.d/README')
+addFilter('spelling-error \(\'builddep|changelog|copr|cron|modulemd|repomanage|repoclosure|reposync\'')

--- a/rpms/dnf5/dnf5.spec
+++ b/rpms/dnf5/dnf5.spec
@@ -7,7 +7,7 @@
 
 Name:           dnf5
 Version:        %{project_version_prime}.%{project_version_major}.%{project_version_minor}.%{project_version_micro}
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Command-line package manager
 License:        GPL-2.0-or-later
 URL:            https://github.com/rpm-software-management/dnf5
@@ -15,6 +15,8 @@ Source0:        %{url}/archive/%{version}/dnf5-%{version}.tar.gz
 Patch1:         0001-Honor-localpkg_gpgcheck-in-RPM-transaction-per-eleme.patch
 Patch2:         0002-Fix-segmentation-fault-in-cmd_requires_privileges.patch
 Patch3:         0003-dnf5daemon-server-Fix-daemon-crash-for-invalid-local.patch
+Patch4:         0004-libdnf5-cli-handle-C-or-POSIX-locale-gracefully-in-p.patch
+Patch5:         0005-tests-Fix-a-type-mismatch-in-libdnf5-cli-test_progre.patch
 
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
@@ -1095,6 +1097,10 @@ mkdir -p %{buildroot}%{_libdir}/libdnf5/plugins
 %ldconfig_scriptlets
 
 %changelog
+* Tue Mar 17 2026 Petr Pisar <ppisar@redhat.com> - 5.4.0.0-5
+- Fix a crash when formatting an RPM scriptlet output containing a non-ASCII
+  character in C locale (bug #2443774)
+
 * Tue Mar 10 2026 Petr Pisar <ppisar@redhat.com> - 5.4.0.0-4
 - Fix a crash in dnf5daemon-server when receiving an unknown locale from
   a D-Bus client (CVE-2026-3836) (bug #2445771)


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: dnf5
- **Version**: 5.4.0.0 → 5.4.0.0
- **Release**: 5
- **Upstream SHA**: `623b0171736b`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/dnf5.git

Automatically synced from Fedora dist-git by Factory.