### PR TITLE
Update langpacks to 4.3

### DIFF
--- a/metadata/langpacks.json
+++ b/metadata/langpacks.json
@@ -2,7 +2,7 @@
   "branch": "rawhide",
   "modification_status": "clean",
   "release": "1",
-  "sha": "6d56f0a0aa3c31f20b536fb97dbb0ff63b3229dc",
+  "sha": "5cfab0b7655e82d5b08b373a0b248e336231b4dc",
   "source": "https://src.fedoraproject.org/rpms/langpacks.git",
   "version": "4.3"
 }

--- a/rpms/langpacks/README.md
+++ b/rpms/langpacks/README.md
@@ -6,15 +6,21 @@ and other packages, as well has default language support
 
 ## Meta-package structure
 
+```
 langpacks-* -> langpacks-{core,fonts}-* -> default-fonts-*
+```
 
 ### Default fonts
 
+```
 default-fonts -> default-fonts-{core,cjk,other}-* -> default-fonts-*
+```
 
+```
 default-fonts-core-* = default-core-{sans,mono,serif,emoji,math}
 default-fonts-cjk-* = default-fonts-cjk-{sans,mono,serif}
 default-fonts-other-* = default-fonts-other-{sans,mono,serif}
+```
 
 ## FAQ
 

--- a/rpms/langpacks/langpacks.spec
+++ b/rpms/langpacks/langpacks.spec
@@ -1,6 +1,6 @@
 Name:      langpacks
 Version:   4.3
-Release:   1.1%{?dist}
+Release:   1%{?dist}
 Summary:   Langpacks meta-package
 
 License:   GPL-2.0-or-later


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: langpacks
- **Version**: 4.3 → 4.3
- **Release**: 1
- **Upstream SHA**: `5cfab0b7655e`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/langpacks.git

Automatically synced from Fedora dist-git by Factory.