### PR TITLE
Update libusb1 to 1.0.29

### DIFF
--- a/metadata/libusb1.json
+++ b/metadata/libusb1.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "1",
-  "sha": "4a3bd6f9ecaa4e74bda93b1ad449fd51f00adf7b",
+  "sha": "695e7278fb33bb591a083cfd9571d6e95f8806dd",
   "source": "https://src.fedoraproject.org/rpms/libusb1.git",
-  "version": "1.0.29",
-  "modification_status": "clean"
+  "version": "1.0.29"
 }

--- a/rpms/libusb1/libusb1.spec
+++ b/rpms/libusb1/libusb1.spec
@@ -3,7 +3,7 @@
 Summary:        Library for accessing USB devices
 Name:           libusb1
 Version:        1.0.29
-Release:        %autorelease
+Release:        1%{?dist}
 Source0:        https://github.com/libusb/libusb/releases/download/v%{version}/libusb-%{version}.tar.bz2
 Source1:        https://github.com/libusb/libusb/releases/download/v%{version}/libusb-%{version}.tar.bz2.asc
 Source2:        https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xc68187379b23de9efc46651e2c80ff56c6830a0e#/%{name}.keyring
@@ -61,8 +61,8 @@ This package contains API documentation for %{name}.
 
 %package        tests-examples
 Summary:        Tests and examples for %{name}
-# The fxload example is GPLv2+, the rest is LGPLv2+, like libusb itself.
-License:        LGPLv2+ and GPLv2+
+# The fxload example is GPL-2.0-or-later, the rest is LGPL-2.1-or-later, like libusb itself.
+License:        LGPL-2.1-or-later AND GPL-2.0-or-later
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Provides:       libusbx-tests-examples = %{version}-%{release}
 Obsoletes:      libusbx-tests-examples < %{version}-%{release}


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: libusb1
- **Version**: 1.0.29 → 1.0.29
- **Release**: 1
- **Upstream SHA**: `695e7278fb33`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/libusb1.git

Automatically synced from Fedora dist-git by Factory.