### PR TITLE
Update make to 4.4.1

### DIFF
--- a/metadata/make.json
+++ b/metadata/make.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "12",
-  "sha": "f591c53cfb99b0696c1a11a394d2cb6889c99abd",
+  "sha": "6734ff476627dd4b5c9bd03b0f56f31cfbb5f9c0",
   "source": "https://src.fedoraproject.org/rpms/make.git",
-  "version": "4.4.1",
-  "modification_status": "clean"
+  "version": "4.4.1"
 }

--- a/rpms/make/gating.yaml
+++ b/rpms/make/gating.yaml
@@ -7,13 +7,8 @@ rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
 --- !Policy
 product_versions:
-  - rhel-8
+  - rhel-*
 decision_context: osci_compose_gate
 rules:
-  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.tier1.functional}
---- !Policy
-product_versions:
-  - rhel-9
-decision_context: osci_compose_gate
-rules:
-  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.tier1.functional}
+  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.gate-build-fast-lane.functional}
+  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.gate-build-slow-lane.functional}


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: make
- **Version**: 4.4.1 → 4.4.1
- **Release**: 12
- **Upstream SHA**: `6734ff476627`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/make.git

Automatically synced from Fedora dist-git by Factory.