### PR TITLE
Update perl-File-Path to 2.18

### DIFF
--- a/metadata/perl-File-Path.json
+++ b/metadata/perl-File-Path.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "522",
-  "sha": "a827f0914ac279af1a8763b1d6324ec8bb8ccbce",
+  "sha": "c5d9b582aa900b054a54d996c8e04e6dc7db17b6",
   "source": "https://src.fedoraproject.org/rpms/perl-File-Path.git",
-  "version": "2.18",
-  "modification_status": "clean"
+  "version": "2.18"
 }

--- a/rpms/perl-File-Path/gating.yaml
+++ b/rpms/perl-File-Path/gating.yaml
@@ -1,16 +1,19 @@
+# Fedora
 --- !Policy
+id: fedora_policy
 product_versions:
   - fedora-*
-decision_context: bodhi_update_push_testing
+decision_contexts:
+  - bodhi_update_push_testing
+  - bodhi_update_push_stable
 subject_type: koji_build
 rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
 
-# Rawhide
+# RHEL
 --- !Policy
 product_versions:
-  - fedora-*
-decision_context: bodhi_update_push_stable
-subject_type: koji_build
+  - rhel-*
+decision_context: osci_compose_gate
 rules:
-  - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
+  - !PassingTestCaseRule {test_case_name: osci.brew-build.tier0.functional}

--- a/rpms/perl-File-Path/plans/internal.fmf
+++ b/rpms/perl-File-Path/plans/internal.fmf
@@ -1,0 +1,12 @@
+summary: Private (RHEL) beakerlib tests
+enabled: false
+adjust:
+  - when: distro == rhel
+    enabled: true
+    because: private tests are accesible only within rhel pipeline
+discover:
+  - name: rhel
+    how: fmf
+    url: https://pkgs.devel.redhat.com/git/tests/perl-File-Path
+execute:
+    how: tmt

--- a/rpms/perl-File-Path/tests/upstream-tests.fmf
+++ b/rpms/perl-File-Path/tests/upstream-tests.fmf
@@ -2,3 +2,10 @@ summary: Upstream tests
 component: perl-File-Path
 require: perl-File-Path-tests
 test: /usr/libexec/perl-File-Path/test
+enabled: true
+tag:
+  - rhel-buildroot
+adjust:
+  - enabled: false
+    when: distro < rhel-10 or distro < centos-stream-10
+    continue: false


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: perl-File-Path
- **Version**: 2.18 → 2.18
- **Release**: 522
- **Upstream SHA**: `c5d9b582aa90`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/perl-File-Path.git

Automatically synced from Fedora dist-git by Factory.