### PR TITLE
Update pyproject-rpm-macros to 1.18.7

### DIFF
--- a/metadata/pyproject-rpm-macros.json
+++ b/metadata/pyproject-rpm-macros.json
@@ -2,7 +2,7 @@
   "branch": "rawhide",
   "modification_status": "clean",
   "release": "1",
-  "sha": "51a3620fd297ec034488b01defacd63c560dfa3c",
+  "sha": "1769a6ec0e43eb67eb91ef64ff83ecdc05be5ce8",
   "source": "https://src.fedoraproject.org/rpms/pyproject-rpm-macros.git",
   "version": "1.18.7"
 }

--- a/rpms/pyproject-rpm-macros/plan.fmf
+++ b/rpms/pyproject-rpm-macros/plan.fmf
@@ -6,10 +6,10 @@ discover:
     tests:
     - name: c9s_mockbuild
       path: /
-      test: NAME="CentOS Stream" VERSION_ID=9 tests/mocktest.sh pyproject-rpm-macros
+      test: ID=centos VERSION_ID=9 tests/mocktest.sh pyproject-rpm-macros
     - name: c10s_mockbuild
       path: /
-      test: NAME="CentOS Stream" VERSION_ID=10 tests/mocktest.sh pyproject-rpm-macros
+      test: ID=centos VERSION_ID=10 tests/mocktest.sh pyproject-rpm-macros
     - name: pytest
       path: /tests
       test: ./mocktest.sh python-pytest
@@ -111,10 +111,10 @@ discover:
       test: ./mocktest.sh config-settings-test
     - name: isort_c9s
       path: /tests
-      test: NAME="CentOS Stream" VERSION_ID=9 ./mocktest.sh python-isort
+      test: ID=centos VERSION_ID=9 ./mocktest.sh python-isort
     - name: isort_c10s
       path: /tests
-      test: NAME="CentOS Stream" VERSION_ID=10 ./mocktest.sh python-isort
+      test: ID=centos VERSION_ID=10 ./mocktest.sh python-isort
 prepare:
   - name: Install dependencies
     how: install

--- a/rpms/pyproject-rpm-macros/tests/mocktest.sh
+++ b/rpms/pyproject-rpm-macros/tests/mocktest.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/bash -eux
-if [ -z "${VERSION_ID-}" ] && [ -z "${NAME-}" ]; then
+if [ -z "${VERSION_ID-}" ] && [ -z "${ID-}" ]; then
   . /etc/os-release
 fi
 
 version=$(echo "${VERSION_ID}" | cut -d. -f1)
 arch=$(rpm --eval '%{_arch}')
 
-case $NAME in
-  "Fedora Linux"|"Fedora")
-    if [ "${VARIANT_ID-}" == "eln" ]; then
+case $ID in
+  "fedora")
+  if [ "${VARIANT_ID-}" == "eln" ]; then
       version="eln"
     fi
     mock="fedora-${version}-${arch}"
     repos="local"
     ;;
 
-  "CentOS Stream"|"Red Hat Enterprise Linux")
+  "centos"|"rhel")
     case $version in
       9)
         mock="centos-stream+epel-next-${version}-${arch}"


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: pyproject-rpm-macros
- **Version**: 1.18.7 → 1.18.7
- **Release**: 1
- **Upstream SHA**: `1769a6ec0e43`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/pyproject-rpm-macros.git

Automatically synced from Fedora dist-git by Factory.