### PR TITLE
Update php-pecl-zip to 1.22.8

### DIFF
--- a/metadata/php-pecl-zip.json
+++ b/metadata/php-pecl-zip.json
@@ -2,7 +2,7 @@
   "branch": "rawhide",
   "modification_status": "clean",
   "release": "3",
-  "sha": "e9955031f28334b8de91604b1ca8778fb04b3072",
+  "sha": "e529c736a5591e5d01322126cc50da48b8d755c5",
   "source": "https://src.fedoraproject.org/rpms/php-pecl-zip.git",
   "version": "1.22.8"
 }

--- a/rpms/php-pecl-zip/php-pecl-zip.spec
+++ b/rpms/php-pecl-zip/php-pecl-zip.spec
@@ -24,10 +24,10 @@
 
 Summary:      A ZIP archive management extension
 Name:         %{php_base}-pecl-zip
-Version:      %{upstream_version}%{?upstream_prever:~%{upstream_prever}}
-%forgemeta
-Release:      3%{?dist}
 License:      PHP-3.01
+Version:      %{upstream_version}%{?upstream_prever:~%{upstream_prever}}
+Release:      3%{?dist}
+%forgemeta
 URL:          %{forgeurl}
 Source0:      %{forgesource}
 
@@ -114,6 +114,7 @@ TEST_PHP_EXECUTABLE=%{__php} \
 
 %files
 %license LICENSE
+%doc composer.json
 %doc CREDITS
 %doc examples
 


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: php-pecl-zip
- **Version**: 1.22.8 → 1.22.8
- **Release**: 3
- **Upstream SHA**: `e529c736a559`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/php-pecl-zip.git

Automatically synced from Fedora dist-git by Factory.