### PR TITLE
Add GitHub Actions workflow to build RPMs on PRs

### DIFF
--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -82,12 +82,18 @@ jobs:
     needs: [detect-packages, build]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - name: Summary
+      - name: Summary and labeling
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           packages='${{ needs.detect-packages.outputs.packages }}'
           count='${{ needs.detect-packages.outputs.count }}'
           build_result='${{ needs.build.result }}'
+          pr_number='${{ github.event.pull_request.number }}'
+          repo='${{ github.repository }}'
 
           echo "## RPM Build Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -110,9 +116,16 @@ jobs:
             fi
           done
 
+          # Signal build status to Factory via PR labels.
           if [[ "${build_result}" == "failure" ]]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "> [!CAUTION]" >> "$GITHUB_STEP_SUMMARY"
             echo "> One or more RPM builds failed. Check individual job logs for details." >> "$GITHUB_STEP_SUMMARY"
+
+            # Add label so the build-fix agent picks up this PR.
+            gh pr edit "${pr_number}" --repo "${repo}" --add-label "build-fix-needed" 2>/dev/null || true
             exit 1
+          else
+            # Build passed — remove the label if it was set by a prior failure.
+            gh pr edit "${pr_number}" --repo "${repo}" --remove-label "build-fix-needed" 2>/dev/null || true
           fi

--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -1,0 +1,118 @@
+name: Build RPMs
+
+on:
+  pull_request:
+    paths:
+      - 'rpms/**'
+      - 'metadata/**'
+      - 'mock/**'
+      - 'ci/build_rpms.sh'
+      - 'ci/package-overrides.yaml'
+      - '.github/workflows/build-rpms.yml'
+
+# Cancel in-progress runs for the same PR when a new commit is pushed.
+concurrency:
+  group: build-rpms-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  detect-packages:
+    name: Detect changed packages
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.detect.outputs.packages }}
+      count: ${{ steps.detect.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed packages
+        id: detect
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          # Find directories under rpms/ that have changed files.
+          packages=$(git diff --name-only "${base}..${head}" -- 'rpms/' \
+            | cut -d/ -f2 \
+            | sort -u \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+          count=$(echo "${packages}" | jq 'length')
+          echo "packages=${packages}" >> "$GITHUB_OUTPUT"
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          echo "Changed packages (${count}): $(echo "${packages}" | jq -r 'join(", ")')"
+
+  build:
+    name: Build ${{ matrix.package }}
+    needs: detect-packages
+    if: needs.detect-packages.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.detect-packages.outputs.packages) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y acl podman
+
+      - name: Build ${{ matrix.package }}
+        run: |
+          # The build script uses `podman run -ti` which requires a TTY.
+          # Replace -ti with -i for non-interactive CI.
+          sed -i 's/--rm -ti --privileged/--rm -i --privileged/' ci/build_rpms.sh
+
+          ./ci/build_rpms.sh --nocheck "${{ matrix.package }}"
+
+      - name: Upload RPMs
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-${{ matrix.package }}
+          path: |
+            builds/${{ matrix.package }}/RPMS/*.rpm
+            builds/${{ matrix.package }}/SRPMS/*.src.rpm
+          retention-days: 7
+
+  results:
+    name: Build results
+    needs: [detect-packages, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summary
+        run: |
+          packages='${{ needs.detect-packages.outputs.packages }}'
+          count='${{ needs.detect-packages.outputs.count }}'
+          build_result='${{ needs.build.result }}'
+
+          echo "## RPM Build Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "${count}" == "0" ]]; then
+            echo "No packages changed in this PR." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "**Packages built:** ${count}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Result:** ${build_result}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          for pkg in $(echo "${packages}" | jq -r '.[]'); do
+            if [[ "${build_result}" == "success" ]]; then
+              echo "| ${pkg} | :white_check_mark: |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| ${pkg} | :x: |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+          if [[ "${build_result}" == "failure" ]]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> [!CAUTION]" >> "$GITHUB_STEP_SUMMARY"
+            echo "> One or more RPM builds failed. Check individual job logs for details." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/rpms/acl/acl.spec
+++ b/rpms/acl/acl.spec
@@ -1,3 +1,4 @@
+# Test CI workflow trigger
 Summary: Access control list utilities
 Name: acl
 Version: 2.3.2

--- a/rpms/acl/acl.spec
+++ b/rpms/acl/acl.spec
@@ -1,4 +1,3 @@
-# Test CI workflow trigger
 Summary: Access control list utilities
 Name: acl
 Version: 2.3.2


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/build-rpms.yml`) that automatically builds RPMs when a PR modifies packages.

### How it works

1. **Trigger**: Fires on PRs that touch `rpms/`, `metadata/`, `mock/`, or the build script
2. **Detect**: Diffs the PR against the base branch to find which `rpms/<package>/` directories changed
3. **Build**: Runs `ci/build_rpms.sh --nocheck <package>` for each changed package in parallel (matrix strategy)
4. **Artifacts**: Uploads built RPMs (binary + source) as workflow artifacts with 7-day retention
5. **Summary**: Posts a build results table to the PR's GitHub Actions summary

### Notes

- Uses `--nocheck` to skip `%check` tests for faster feedback (full test runs remain in the Konflux pipeline)
- Patches `podman run -ti` to `podman run -i` for headless CI runners
- Cancels in-progress builds when new commits are pushed to the same PR
- `fail-fast: false` so all packages build even if one fails

This will be used as part of the Factory reconciler loop: when distgit-sync or upstream-version-check creates a PR, this workflow validates the package builds successfully.