### PR TITLE
Update dbus to 1.16.2

### DIFF
--- a/metadata/dbus.json
+++ b/metadata/dbus.json
@@ -2,7 +2,7 @@
   "branch": "rawhide",
   "modification_status": "clean",
   "release": "1",
-  "sha": "8b08d4f2e3d44d0595b79990f0d83e5b09d5e60a",
+  "sha": "f6d0b84c4ddfbd13777540ea628c25cd7026347c",
   "source": "https://src.fedoraproject.org/rpms/dbus.git",
   "version": "1.16.2"
 }

--- a/rpms/dbus/monitoring.toml
+++ b/rpms/dbus/monitoring.toml
@@ -1,0 +1,13 @@
+# Enable/disable monitoring
+monitoring = false
+# Enable/disable filling bugzilla ticket for new release
+# When disabled it will also disable scratch builds
+bugzilla = true
+# Enable/disable reporting only stable versions
+# Stable versions are recognized based on release-monitoring.org project settings
+stable_only = false
+# Enable/disable reporting all new versions instead of the latest one
+# Enabling this will disable scratch builds
+all_versions = false
+# Enable/disable scratch build for newly opened version
+scratch_build = false


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: dbus
- **Version**: 1.16.2 → 1.16.2
- **Release**: 1
- **Upstream SHA**: `f6d0b84c4ddf`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/dbus.git

Automatically synced from Fedora dist-git by Factory.