### PR TITLE
Update libyuv to 0

### DIFF
--- a/metadata/libyuv.json
+++ b/metadata/libyuv.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
   "modification_status": "clean",
-  "release": "0.61.20260213git6067afd",
-  "sha": "03c659eb59c42ecbca6b522b7d4df8222a55289b",
+  "release": "0.1.20260213git6067afd",
+  "sha": "10ae99a60fa82e911d04df30760d4b9be52797c4",
   "source": "https://src.fedoraproject.org/rpms/libyuv.git",
   "version": "0"
 }

--- a/rpms/libyuv/libyuv.spec
+++ b/rpms/libyuv/libyuv.spec
@@ -4,7 +4,7 @@
 Name:		libyuv
 Summary:	YUV conversion and scaling functionality library
 Version:	0
-Release:	0.61.20260213git6067afd%{?dist}
+Release:	0.1.20260213git6067afd%{?dist} -p -s %{git_date}git%{sub %git_commit 0 7}
 License:	BSD-3-Clause
 Url:		https://chromium.googlesource.com/libyuv/libyuv
 VCS:		git:%{url}
@@ -19,7 +19,6 @@ Patch:		libyuv-0006-Don-t-install-tools-and-static-lib.patch
 BuildRequires:	cmake
 BuildRequires:	cmake(GTest)
 BuildRequires:	gcc-c++
-BuildRequires:	gtest-devel
 BuildRequires:	pkgconfig(libjpeg)
 
 
@@ -57,24 +56,18 @@ EOF
 
 
 %build
-# TODO: Please submit an issue to upstream (rhbz#2380770)
-export CMAKE_POLICY_VERSION_MINIMUM=3.5
 %{cmake} -DUNIT_TEST=TRUE
 %{cmake_build}
 
 
 %install
 %{cmake_install}
-
-mkdir -p %{buildroot}%{_libdir}/pkgconfig
-cp -a %{name}.pc %{buildroot}%{_libdir}/pkgconfig/
-
-# FIXME
-rm -f %{buildroot}%{_bindir}/yuvconvert
+install -D -p -m 0644  %{name}.pc %{buildroot}%{_libdir}/pkgconfig/%{name}.pc
 
 
 %check
-# FIXME fails again on s390
+# FIXME 42 of 3438 tests fail on s390x due to big-endian byte order assumptions
+# in packed pixel formats (RGB565, AR30, AB30). Core YUV operations pass.
 %ifnarch s390x
 %{ctest}
 %endif


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: libyuv
- **Version**: 0 → 0
- **Release**: 0.1.20260213git6067afd
- **Upstream SHA**: `10ae99a60fa8`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/libyuv.git

Automatically synced from Fedora dist-git by Factory.