### PR TITLE
Update libipt to 2.1.2

### DIFF
--- a/metadata/libipt.json
+++ b/metadata/libipt.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "4",
-  "sha": "cd49f09fe11b0850c4837795922e112eab84a8c3",
+  "sha": "8ec28cd791a9d062164d6bfea50a7c8943bbcc53",
   "source": "https://src.fedoraproject.org/rpms/libipt.git",
-  "version": "2.1.2",
-  "modification_status": "clean"
+  "version": "2.1.2"
 }

--- a/rpms/libipt/gating.yaml
+++ b/rpms/libipt/gating.yaml
@@ -1,0 +1,6 @@
+--- !Policy
+product_versions:
+  - rhel-*
+decision_context: osci_compose_gate
+rules:
+  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.gate-build-fast-lane.functional}


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: libipt
- **Version**: 2.1.2 → 2.1.2
- **Release**: 4
- **Upstream SHA**: `8ec28cd791a9`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/libipt.git

Automatically synced from Fedora dist-git by Factory.