### PR TITLE
Update pcre2 to 10.47

### DIFF
--- a/metadata/pcre2.json
+++ b/metadata/pcre2.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
-  "release": "1",
-  "sha": "7564d9d768d993dc417a65d0c9c66d9a857d527d",
+  "modification_status": "clean",
+  "release": "1.1",
+  "sha": "d82b454176c3c6badb10fd61b87115100f6d43b9",
   "source": "https://src.fedoraproject.org/rpms/pcre2.git",
-  "version": "10.47",
-  "modification_status": "clean"
+  "version": "10.47"
 }

--- a/rpms/pcre2/pcre2.spec
+++ b/rpms/pcre2/pcre2.spec
@@ -9,7 +9,7 @@
 #%%global rcversion RC1
 Name:       pcre2
 Version:    10.47
-Release:    %{?rcversion:0.}1%{?rcversion:.%rcversion}%{?dist}
+Release:    %{?rcversion:0.}1%{?rcversion:.%rcversion}%{?dist}.1
 %global     myversion %{version}%{?rcversion:-%rcversion}
 Summary:    Perl-compatible regular expression library
 # the library:                          BSD with exceptions
@@ -262,6 +262,9 @@ make %{?_smp_mflags} check VERBOSE=yes
 %{_mandir}/man1/pcre2test.*
 
 %changelog
+* Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 10.47-1.1
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
 * Fri Nov 07 2025 Lukas Javorsky <ljavorsk@redhat.com> - 10.47-1
 - Rebase to version 10.47
 - Resolves: rhbz#2405255


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: pcre2
- **Version**: 10.47 → 10.47
- **Release**: 1.1
- **Upstream SHA**: `d82b454176c3`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/pcre2.git

Automatically synced from Fedora dist-git by Factory.