### PR TITLE
Update perl-Data-Dumper to 2.191

### DIFF
--- a/metadata/perl-Data-Dumper.json
+++ b/metadata/perl-Data-Dumper.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "522",
-  "sha": "3e8968f6f626b54247e7de9d78ce2086d6082ae8",
+  "sha": "d0285145a89c6e0686e29aeae6991cba5fb1393b",
   "source": "https://src.fedoraproject.org/rpms/perl-Data-Dumper.git",
-  "version": "2.191",
-  "modification_status": "clean"
+  "version": "2.191"
 }

--- a/rpms/perl-Data-Dumper/gating.yaml
+++ b/rpms/perl-Data-Dumper/gating.yaml
@@ -1,7 +1,19 @@
+# Fedora
 --- !Policy
+id: fedora_policy
 product_versions:
   - fedora-*
-decision_context: bodhi_update_push_stable
+decision_contexts:
+  - bodhi_update_push_testing
+  - bodhi_update_push_stable
 subject_type: koji_build
 rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
+
+# RHEL
+--- !Policy
+product_versions:
+  - rhel-*
+decision_context: osci_compose_gate
+rules:
+  - !PassingTestCaseRule {test_case_name: osci.brew-build.tier0.functional}

--- a/rpms/perl-Data-Dumper/plans/internal.fmf
+++ b/rpms/perl-Data-Dumper/plans/internal.fmf
@@ -1,0 +1,12 @@
+summary: Private (RHEL) beakerlib tests
+enabled: false
+adjust:
+  - when: distro == rhel
+    enabled: true
+    because: private tests are accesible only within rhel pipeline
+discover:
+  - name: rhel
+    how: fmf
+    url: https://pkgs.devel.redhat.com/git/tests/perl-Data-Dumper
+execute:
+    how: tmt

--- a/rpms/perl-Data-Dumper/tests/upstream-tests.fmf
+++ b/rpms/perl-Data-Dumper/tests/upstream-tests.fmf
@@ -2,3 +2,10 @@ summary: Upstream tests
 component: perl-Data-Dumper
 require: perl-Data-Dumper-tests
 test: /usr/libexec/perl-Data-Dumper/test
+enabled: true
+tag:
+  - rhel-buildroot
+adjust:
+  - enabled: false
+    when: distro < rhel-10 or distro < centos-stream-10
+    continue: false


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: perl-Data-Dumper
- **Version**: 2.191 → 2.191
- **Release**: 522
- **Upstream SHA**: `d0285145a89c`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/perl-Data-Dumper.git

Automatically synced from Fedora dist-git by Factory.