### PR TITLE
Update perl-Carp to 1.54

### DIFF
--- a/metadata/perl-Carp.json
+++ b/metadata/perl-Carp.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "521",
-  "sha": "19648ad4c53cf8b2871043dd012f54941507b7c2",
+  "sha": "6a10b40ead4808ce46880bbb2b9b35e9c4699340",
   "source": "https://src.fedoraproject.org/rpms/perl-Carp.git",
-  "version": "1.54",
-  "modification_status": "clean"
+  "version": "1.54"
 }

--- a/rpms/perl-Carp/gating.yaml
+++ b/rpms/perl-Carp/gating.yaml
@@ -1,7 +1,19 @@
+# Fedora
 --- !Policy
+id: fedora_policy
 product_versions:
   - fedora-*
-decision_context: bodhi_update_push_stable
+decision_contexts:
+  - bodhi_update_push_testing
+  - bodhi_update_push_stable
 subject_type: koji_build
 rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
+
+# RHEL
+--- !Policy
+product_versions:
+  - rhel-*
+decision_context: osci_compose_gate
+rules:
+  - !PassingTestCaseRule {test_case_name: osci.brew-build.tier0.functional}

--- a/rpms/perl-Carp/perl-Carp.spec
+++ b/rpms/perl-Carp/perl-Carp.spec
@@ -1,7 +1,7 @@
 %global base_version 1.50
 Name:           perl-Carp
 Version:        1.54
-Release:        521.1%{?dist}
+Release:        521%{?dist}
 Summary:        Alternative warn and die for modules
 License:        GPL-1.0-or-later OR Artistic-1.0-Perl
 URL:            https://metacpan.org/release/Carp

--- a/rpms/perl-Carp/plans/internal.fmf
+++ b/rpms/perl-Carp/plans/internal.fmf
@@ -1,0 +1,12 @@
+summary: Private (RHEL) beakerlib tests
+enabled: false
+adjust:
+  - when: distro == rhel
+    enabled: true
+    because: private tests are accesible only within rhel pipeline
+discover:
+  - name: rhel
+    how: fmf
+    url: https://pkgs.devel.redhat.com/git/tests/perl-Carp
+execute:
+    how: tmt

--- a/rpms/perl-Carp/tests/upstream-tests.fmf
+++ b/rpms/perl-Carp/tests/upstream-tests.fmf
@@ -2,3 +2,10 @@ summary: Upstream tests
 component: perl-Carp
 require: perl-Carp-tests
 test: /usr/libexec/perl-Carp/test
+enabled: true
+tag:
+  - rhel-buildroot
+adjust:
+  - enabled: false
+    when: distro < rhel-10 or distro < centos-stream-10
+    continue: false


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: perl-Carp
- **Version**: 1.54 → 1.54
- **Release**: 521
- **Upstream SHA**: `6a10b40ead48`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/perl-Carp.git

Automatically synced from Fedora dist-git by Factory.