### PR TITLE
Update perl-Exporter to 5.79

### DIFF
--- a/metadata/perl-Exporter.json
+++ b/metadata/perl-Exporter.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "521",
-  "sha": "371d31259913b789c8a4a863e998c9b58a2305d0",
+  "sha": "a383ed23b95272e67cc28d513cd1e06d9954b417",
   "source": "https://src.fedoraproject.org/rpms/perl-Exporter.git",
-  "version": "5.79",
-  "modification_status": "clean"
+  "version": "5.79"
 }

--- a/rpms/perl-Exporter/gating.yaml
+++ b/rpms/perl-Exporter/gating.yaml
@@ -1,16 +1,19 @@
+# Fedora
 --- !Policy
+id: fedora_policy
 product_versions:
   - fedora-*
-decision_context: bodhi_update_push_testing
+decision_contexts:
+  - bodhi_update_push_testing
+  - bodhi_update_push_stable
 subject_type: koji_build
 rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
 
-# Rawhide
+# RHEL
 --- !Policy
 product_versions:
-  - fedora-*
-decision_context: bodhi_update_push_stable
-subject_type: koji_build
+  - rhel-*
+decision_context: osci_compose_gate
 rules:
-  - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
+  - !PassingTestCaseRule {test_case_name: osci.brew-build.tier0.functional}

--- a/rpms/perl-Exporter/plans/internal.fmf
+++ b/rpms/perl-Exporter/plans/internal.fmf
@@ -1,0 +1,12 @@
+summary: Private (RHEL) beakerlib tests
+enabled: false
+adjust:
+  - when: distro == rhel
+    enabled: true
+    because: private tests are accesible only within rhel pipeline
+discover:
+  - name: rhel
+    how: fmf
+    url: https://pkgs.devel.redhat.com/git/tests/perl-Exporter
+execute:
+    how: tmt

--- a/rpms/perl-Exporter/tests/upstream-tests.fmf
+++ b/rpms/perl-Exporter/tests/upstream-tests.fmf
@@ -2,3 +2,10 @@ summary: Upstream tests
 component: perl-Exporter
 require: perl-Exporter-tests
 test: /usr/libexec/perl-Exporter/test
+enabled: true
+tag:
+  - rhel-buildroot
+adjust:
+  - enabled: false
+    when: distro < rhel-10 or distro < centos-stream-10
+    continue: false


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: perl-Exporter
- **Version**: 5.79 → 5.79
- **Release**: 521
- **Upstream SHA**: `a383ed23b952`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/perl-Exporter.git

Automatically synced from Fedora dist-git by Factory.