### PR TITLE
Update perl-Encode to 3.21

### DIFF
--- a/metadata/perl-Encode.json
+++ b/metadata/perl-Encode.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "521",
-  "sha": "8d0a740f39cbd2c1af75ad80280eb0bd7597f264",
+  "sha": "75524db7db2aa5988d3f168cedc9edbe9c59822a",
   "source": "https://src.fedoraproject.org/rpms/perl-Encode.git",
-  "version": "3.21",
-  "modification_status": "clean"
+  "version": "3.21"
 }

--- a/rpms/perl-Encode/gating.yaml
+++ b/rpms/perl-Encode/gating.yaml
@@ -1,16 +1,19 @@
+# Fedora
 --- !Policy
+id: fedora_policy
 product_versions:
   - fedora-*
-decision_context: bodhi_update_push_testing
+decision_contexts:
+  - bodhi_update_push_testing
+  - bodhi_update_push_stable
 subject_type: koji_build
 rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
 
-# Rawhide
+# RHEL
 --- !Policy
 product_versions:
-  - fedora-*
-decision_context: bodhi_update_push_stable
-subject_type: koji_build
+  - rhel-*
+decision_context: osci_compose_gate
 rules:
-  - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
+  - !PassingTestCaseRule {test_case_name: osci.brew-build.tier0.functional}

--- a/rpms/perl-Encode/plans/internal.fmf
+++ b/rpms/perl-Encode/plans/internal.fmf
@@ -1,0 +1,12 @@
+summary: Private (RHEL) beakerlib tests
+enabled: false
+adjust:
+  - when: distro == rhel
+    enabled: true
+    because: private tests are accesible only within rhel pipeline
+discover:
+  - name: rhel
+    how: fmf
+    url: https://pkgs.devel.redhat.com/git/tests/perl-Encode
+execute:
+    how: tmt

--- a/rpms/perl-Encode/tests/upstream-tests.fmf
+++ b/rpms/perl-Encode/tests/upstream-tests.fmf
@@ -2,3 +2,10 @@ summary: Upstream tests
 component: perl-Encode
 require: perl-Encode-tests
 test: /usr/libexec/perl-Encode/test
+enabled: true
+tag:
+  - rhel-buildroot
+adjust:
+  - enabled: false
+    when: distro < rhel-10 or distro < centos-stream-10
+    continue: false


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: perl-Encode
- **Version**: 3.21 → 3.21
- **Release**: 521
- **Upstream SHA**: `75524db7db2a`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/perl-Encode.git

Automatically synced from Fedora dist-git by Factory.