### PR TITLE
Update python-setuptools to 80.10.2

### DIFF
--- a/metadata/python-setuptools.json
+++ b/metadata/python-setuptools.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
   "modification_status": "clean",
-  "release": "3",
-  "sha": "ea61f055948b7735a0a0c6473f2382b239f5d20b",
+  "release": "1",
+  "sha": "1dcaa5327549fb89c82d9560785b687eb95feb5b",
   "source": "https://src.fedoraproject.org/rpms/python-setuptools.git",
   "version": "80.10.2"
 }

--- a/rpms/python-setuptools/plan.fmf
+++ b/rpms/python-setuptools/plan.fmf
@@ -15,10 +15,26 @@ discover:
   - name: same_repo
     how: shell
     dist-git-source: true
-    dist-git-download-only: true
     tests:
     - name: import_test
       test: python3 -c "import setuptools"
+    - name: upstream_tests
+      environment:
+        PIP_NO_BUILD_ISOLATION: 0
+      test: |
+        cd $(dirname $TMT_SOURCE_DIR/*/pyproject.toml)
+        python3 -m pip install --uploaded-prior-to='2026-03-10T00:00:00Z' '.[test]'
+        python3 -m pip uninstall --yes setuptools
+        PYTHONPATH=$(pwd) \
+          PRE_BUILT_SETUPTOOLS_WHEEL=$(rpm -ql python-setuptools-wheel | grep whl$) \
+          pytest \
+          --ignore=setuptools/tests/integration/ \
+          --ignore=setuptools/tests/test_editable_install.py \
+          --ignore=setuptools/tests/config/test_apply_pyprojecttoml.py \
+          --ignore=tools \
+          -k "not test_wheel_includes_cli_scripts" \
+          -n auto
+        rm -rf /usr/local/bin/* /usr/local/lib*/python*
     - name: mock_bootstrap_build
       # Needs cwd to contain downloaded sources, path to mocktest.sh depends on tmt tree structure
       test: |
@@ -27,6 +43,14 @@ discover:
   - name: tests_python
     how: shell
     url: https://src.fedoraproject.org/tests/python.git
+    tests:
+    - name: smoke314_virtualenv
+      path: /smoke
+      test:  VERSION=3.14 METHOD=virtualenv VIRTUALENV_SETUPTOOLS=bundle ./venv.sh
+  - name: tests_python_fedora_only
+    how: shell
+    url: https://src.fedoraproject.org/tests/python.git
+    when: distro != fedora-eln and distro == fedora
     tests:
     - name: smoke36
       path: /smoke
@@ -55,22 +79,20 @@ discover:
     - name: smoke313_virtualenv
       path: /smoke
       test:  VERSION=3.13 METHOD=virtualenv VIRTUALENV_SETUPTOOLS=bundle ./venv.sh
-    - name: smoke314_virtualenv
+    - name: smoke315_virtualenv
       path: /smoke
-      test:  VERSION=3.14 METHOD=virtualenv VIRTUALENV_SETUPTOOLS=bundle ./venv.sh
+      test:  VERSION=3.15 METHOD=virtualenv VIRTUALENV_SETUPTOOLS=bundle ./venv.sh
 
 prepare:
   - name: Install dependencies
     how: install
     package:
+    - python3-setuptools
+    - python-setuptools-wheel
+    - python3-pip
+    - python3-test
     - gcc
     - virtualenv
-    - python3.6-devel
-    - python3.9-devel
-    - python3.10-devel
-    - python3.11-devel
-    - python3.12-devel
-    - python3.13-devel
     - python3.14-devel
     - python3-devel
     - python3-tox
@@ -78,6 +100,17 @@ prepare:
     - rpmdevtools
     - rpm-build
     - dnf
+  - name: Install dependencies (Fedora not ELN)
+    how: install
+    when: distro != fedora-eln and distro == fedora
+    package:
+    - python3.6-devel
+    - python3.9-devel
+    - python3.10-devel
+    - python3.11-devel
+    - python3.12-devel
+    - python3.13-devel
+    - python3.15-devel
   - name: Update packages
     how: shell
     script: dnf upgrade -y

--- a/rpms/python-setuptools/python-setuptools.spec
+++ b/rpms/python-setuptools/python-setuptools.spec
@@ -1,5 +1,3 @@
-%global srcname setuptools
-
 # used when bootstrapping new Python versions
 %bcond bootstrap 0
 
@@ -8,12 +6,12 @@
 # to prevent pulling many unwanted packages in.
 %bcond tests %[%{without bootstrap} && %{defined fedora}]
 
-%global python_wheel_name %{srcname}-%{version}-py3-none-any.whl
+%global python_wheel_name setuptools-%{version}-py3-none-any.whl
 
 Name:           python-setuptools
 # When updating, update the bundled libraries versions bellow!
 Version:        80.10.2
-Release:        3%{?dist}
+Release:        1%{?dist}
 Summary:        Easily build and distribute Python packages
 # setuptools is MIT
 # autocommand is LGPL-3.0-only
@@ -30,8 +28,8 @@ Summary:        Easily build and distribute Python packages
 # zipp is MIT
 # the setuptools logo is MIT
 License:        MIT AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0) AND LGPL-3.0-only
-URL:            https://pypi.python.org/pypi/%{srcname}
-Source0:        %{pypi_source %{srcname} %{version}}
+URL:            https://pypi.python.org/pypi/setuptools
+Source0:        %{pypi_source setuptools %{version}}
 
 # Some test deps are optional and either not desired or not available in Fedora, thus this patch removes them.
 Patch:          Remove-optional-or-unpackaged-test-deps.patch
@@ -120,23 +118,21 @@ This package also contains the runtime components of setuptools, necessary to
 execute the software that requires pkg_resources.
 
 
-%package -n     %{python_wheel_pkg_prefix}-%{srcname}-wheel
+%package -n     %{python_wheel_pkg_prefix}-setuptools-wheel
 Summary:        The setuptools wheel
 %{bundled}
 
-%description -n %{python_wheel_pkg_prefix}-%{srcname}-wheel
+%description -n %{python_wheel_pkg_prefix}-setuptools-wheel
 A Python wheel of setuptools to use with venv.
 
 
 %prep
-%autosetup -p1 -n %{srcname}-%{version}
+%autosetup -p1 -n setuptools-%{version}
 %if %{without bootstrap}
 # If we don't have setuptools installed yet, we use the pre-generated .egg-info
 # See https://github.com/pypa/setuptools/pull/2543
 # And https://github.com/pypa/setuptools/issues/2550
-# WARNING: We cannot remove this folder since Python 3.11.1,
-#          see https://github.com/pypa/setuptools/issues/3761
-#rm -r %%{srcname}.egg-info
+rm -r setuptools.egg-info
 %endif
 
 # Strip shbang
@@ -241,7 +237,7 @@ PYTHONPATH=$(pwd) %pytest \
 %{python3_sitelib}/_distutils_hack/
 %endif
 
-%files -n %{python_wheel_pkg_prefix}-%{srcname}-wheel
+%files -n %{python_wheel_pkg_prefix}-setuptools-wheel
 %license LICENSE
 # we own the dir for simplicity
 %dir %{python_wheel_dir}/


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: python-setuptools
- **Version**: 80.10.2 → 80.10.2
- **Release**: 1
- **Upstream SHA**: `1dcaa5327549`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/python-setuptools.git

Automatically synced from Fedora dist-git by Factory.