### PR TITLE
Update unbound to 1.24.2

### DIFF
--- a/metadata/unbound.json
+++ b/metadata/unbound.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
   "modification_status": "clean",
-  "release": "10",
-  "sha": "2ec051502725628163fc7fc600b71341574a3b14",
+  "release": "1",
+  "sha": "c400bb086a2b2fbd79fe63060713aa5d449f77fd",
   "source": "https://src.fedoraproject.org/rpms/unbound.git",
   "version": "1.24.2"
 }

--- a/rpms/unbound/module-setup.sh
+++ b/rpms/unbound/module-setup.sh
@@ -14,11 +14,6 @@ depends() {
 }
 
 install() {
-    # We have to make unbound wanted by network-online target to make sure
-    # there is a synchronization point when other services are able
-    # to make queries
-    inst_simple "$moddir"/unbound-initrd.conf /etc/systemd/system/unbound.service.d/unbound-initrd.conf
-
     # /etc and /var/lib do not have its variables
     inst_multiple -o \
     "$systemdsystemunitdir"/unbound.service \
@@ -39,6 +34,4 @@ install() {
     unbound \
     unbound-checkconf \
     unbound-control
-
-    $SYSTEMCTL -q --root "$initdir" enable unbound.service
 }

--- a/rpms/unbound/unbound-initrd.conf
+++ b/rpms/unbound/unbound-initrd.conf
@@ -1,5 +1,0 @@
-[Unit]
-Before=network-online.target
-
-[Install]
-WantedBy=network-online.target

--- a/rpms/unbound/unbound.spec
+++ b/rpms/unbound/unbound.spec
@@ -41,7 +41,7 @@
 Summary: Validating, recursive, and caching DNS(SEC) resolver
 Name: unbound
 Version: 1.24.2
-Release: 10%{?dist}
+Release: 1%{?dist} %{?extra_version:-e %{extra_version}}
 License: BSD-3-Clause
 Url: https://nlnetlabs.nl/projects/unbound/
 VCS: git:%{forgeurl0}
@@ -72,8 +72,7 @@ Source25: openssl-sha1.conf
 Source26: remote-control-include.conf
 Source27: fedora-defaults.conf
 Source28: module-setup.sh
-Source29: unbound-initrd.conf
-Source30: tmpfiles-unbound-libs.conf
+Source29: tmpfiles-unbound-libs.conf
 
 # Downstream configuration changes
 Patch1:   unbound-fedora-config.patch
@@ -375,7 +374,7 @@ install -p -D -m 0644 contrib/libunbound.pc %{buildroot}/%{_libdir}/pkgconfig/li
 # Install tmpfiles.d config
 install -d -m 0755 %{buildroot}%{_tmpfilesdir} %{buildroot}%{_sharedstatedir}/unbound
 install -p -m 0644 %{SOURCE8} %{buildroot}%{_tmpfilesdir}/unbound.conf
-install -p -m 0644 %{SOURCE30} %{buildroot}%{_tmpfilesdir}/unbound-libs.conf
+install -p -m 0644 %{SOURCE29} %{buildroot}%{_tmpfilesdir}/unbound-libs.conf
 
 # install root - we keep a copy of the root key in old location,
 # in case user has changed the configuration and we wouldn't update it there
@@ -417,10 +416,9 @@ install -p -m 0644 %{SOURCE27} %{buildroot}%{_datadir}/%{name}/
 echo ".so man8/unbound-control.8" > %{buildroot}/%{_mandir}/man8/unbound-control-setup.8
 
 # install dracut module
-mkdir -p %{buildroot}%{_prefix}/lib/dracut/modules.d/99unbound
+mkdir -p %{buildroot}%{_prefix}/lib/dracut/modules.d/70unbound
 
-install -p -m 0755 %{SOURCE28} %{buildroot}%{_prefix}/lib/dracut/modules.d/99unbound
-install -p -m 0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/dracut/modules.d/99unbound
+install -p -m 0755 %{SOURCE28} %{buildroot}%{_prefix}/lib/dracut/modules.d/70unbound
 
 
 %post
@@ -553,7 +551,7 @@ popd
 %{_mandir}/man1/unbound-*
 
 %files dracut
-%{_prefix}/lib/dracut/modules.d/99unbound
+%{_prefix}/lib/dracut/modules.d/70unbound
 
 %changelog
 %autochangelog


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: unbound
- **Version**: 1.24.2 → 1.24.2
- **Release**: 1
- **Upstream SHA**: `c400bb086a2b`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/unbound.git

Automatically synced from Fedora dist-git by Factory.