### PR TITLE
Update tpm2-tss to 4.1.3

### DIFF
--- a/metadata/tpm2-tss.json
+++ b/metadata/tpm2-tss.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
-  "release": "8",
-  "sha": "7f13b9f2a3811b0ef4587e9f10dac18a2081406e",
+  "modification_status": "clean",
+  "release": "9",
+  "sha": "b7fcc893b554c2c3bcd63dd84a2a0d49f4059ab5",
   "source": "https://src.fedoraproject.org/rpms/tpm2-tss.git",
-  "version": "4.1.3",
-  "modification_status": "clean"
+  "version": "4.1.3"
 }

--- a/rpms/tpm2-tss/tpm2-tss.spec
+++ b/rpms/tpm2-tss/tpm2-tss.spec
@@ -5,11 +5,9 @@
 
 Name:          tpm2-tss
 Version:       4.1.3
-Release:       8%{?candidate:.%{candidate}}%{?dist}
+Release:       9%{?candidate:.%{candidate}}%{?dist}
 Summary:       TPM2.0 Software Stack
 
-# The entire source code is under BSD except implementation.h and tpmb.h which
-# is under TCGL(Trusted Computing Group License).
 License:       BSD-2-Clause
 URL:           https://github.com/tpm2-software/tpm2-tss
 Source0:       %{url}/releases/download/%{version}/%{name}-%{version}%{?candidate:-%{candidate}}.tar.gz
@@ -155,6 +153,9 @@ use tpm2-tss.
 %{_mandir}/man7/tss2*.7.gz
 
 %changelog
+* Sat Jan 17 2026 Fedora Release Engineering <releng@fedoraproject.org> - 4.1.3-9
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
 * Fri Jul 25 2025 Fedora Release Engineering <releng@fedoraproject.org> - 4.1.3-8
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_43_Mass_Rebuild
 


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: tpm2-tss
- **Version**: 4.1.3 → 4.1.3
- **Release**: 9
- **Upstream SHA**: `b7fcc893b554`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/tpm2-tss.git

Automatically synced from Fedora dist-git by Factory.