### PR TITLE
Update dnf to 4.24.0

### DIFF
--- a/metadata/dnf.json
+++ b/metadata/dnf.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
-  "release": "1",
-  "sha": "dd7d4efb45cb58e1df05e6c192ffb4aef54946ff",
+  "modification_status": "clean",
+  "release": "3",
+  "sha": "4e96f2e64d0cac2646ceed5a759e82e173a02dab",
   "source": "https://src.fedoraproject.org/rpms/dnf.git",
-  "version": "4.24.0",
-  "modification_status": "clean"
+  "version": "4.24.0"
 }

--- a/rpms/dnf/dnf.spec
+++ b/rpms/dnf/dnf.spec
@@ -51,7 +51,7 @@ It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
 Version:        4.24.0
-Release:        1.1%{?dist}
+Release:        3%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING
 License:        GPL-2.0-or-later AND GPL-1.0-only
@@ -413,6 +413,12 @@ fi
 # bootc subpackage does not include any files
 
 %changelog
+* Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 4.24.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
+* Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 4.24.0-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
 * Tue Oct 21 2025 Petr Pisar <ppisar@redhat.com> - 4.24.0-1
 - 4.24.0 bump
 

--- a/rpms/dnf/rpminspect.yaml
+++ b/rpms/dnf/rpminspect.yaml
@@ -1,0 +1,4 @@
+---
+inspections:
+  # dnf-bootc is an empty metapackage.
+  emptyrpm: off


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: dnf
- **Version**: 4.24.0 → 4.24.0
- **Release**: 3
- **Upstream SHA**: `4e96f2e64d0c`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/dnf.git

Automatically synced from Fedora dist-git by Factory.