### PR TITLE
Update libtool to 2.5.4

### DIFF
--- a/metadata/libtool.json
+++ b/metadata/libtool.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
-  "release": "9",
-  "sha": "8ea49f350ba69b0379d603cdad069b41c94c155a",
+  "modification_status": "clean",
+  "release": "10",
+  "sha": "52fc02f48fb2787e16c78c3b9e1e8c89b026ffe9",
   "source": "https://src.fedoraproject.org/rpms/libtool.git",
-  "version": "2.5.4",
-  "modification_status": "clean"
+  "version": "2.5.4"
 }

--- a/rpms/libtool/libtool.spec
+++ b/rpms/libtool/libtool.spec
@@ -8,7 +8,7 @@
 Summary: The GNU Portable Library Tool
 Name:    libtool
 Version: 2.5.4
-Release: 9%{?dist}
+Release: 10%{?dist}
 
 # To help future rebase, the following licenses were seen in the following files/folders:
 # '*' is anything that was not explicitly listed earlier in the folder
@@ -116,7 +116,7 @@ and GNU Automake).
 %package ltdl
 Summary:  Runtime libraries for GNU Libtool Dynamic Module Loader
 Provides: %{name}-libs = %{version}-%{release}
-License:  LGPLv2+
+License:  LGPL-2.0-or-later WITH Libtool-exception
 
 
 %description ltdl
@@ -133,7 +133,7 @@ the rest of the GNU Autotools (including GNU Autoconf and GNU Automake).
 Summary: Tools needed for development using the GNU Libtool Dynamic Module Loader
 Requires: automake = %automake_version
 Requires: %{name}-ltdl = %{version}-%{release}
-License:  LGPLv2+
+License:  LGPL-2.0-or-later WITH Libtool-exception
 
 
 %description ltdl-devel
@@ -199,6 +199,9 @@ rm -f %{buildroot}%{_libdir}/libltdl.{a,la}
 
 
 %changelog
+* Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 2.5.4-10
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
 * Sat Dec 20 2025 Jakub Jelinek <jakub@redhat.com> - 2.5.4-9
 - bump: for gcc 16.* in rawhide
 


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: libtool
- **Version**: 2.5.4 → 2.5.4
- **Release**: 10
- **Upstream SHA**: `52fc02f48fb2`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/libtool.git

Automatically synced from Fedora dist-git by Factory.