### PR TITLE
Update perl-Digest to 1.20

### DIFF
--- a/metadata/perl-Digest.json
+++ b/metadata/perl-Digest.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "521",
-  "sha": "40ffb73d2df02bddbb62043de688e690aef6cda6",
+  "sha": "66a3c0dcfa0535591f453b6820b4095b9307677d",
   "source": "https://src.fedoraproject.org/rpms/perl-Digest.git",
-  "version": "1.20",
-  "modification_status": "clean"
+  "version": "1.20"
 }

--- a/rpms/perl-Digest/gating.yaml
+++ b/rpms/perl-Digest/gating.yaml
@@ -1,7 +1,19 @@
+# Fedora
 --- !Policy
+id: fedora_policy
 product_versions:
   - fedora-*
-decision_context: bodhi_update_push_stable
+decision_contexts:
+  - bodhi_update_push_testing
+  - bodhi_update_push_stable
 subject_type: koji_build
 rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
+
+# RHEL
+--- !Policy
+product_versions:
+  - rhel-*
+decision_context: osci_compose_gate
+rules:
+  - !PassingTestCaseRule {test_case_name: osci.brew-build.tier0.functional}

--- a/rpms/perl-Digest/plans/internal.fmf
+++ b/rpms/perl-Digest/plans/internal.fmf
@@ -1,0 +1,12 @@
+summary: Private (RHEL) beakerlib tests
+enabled: false
+adjust:
+  - when: distro == rhel
+    enabled: true
+    because: private tests are accesible only within rhel pipeline
+discover:
+  - name: rhel
+    how: fmf
+    url: https://pkgs.devel.redhat.com/git/tests/perl-Digest
+execute:
+    how: tmt

--- a/rpms/perl-Digest/tests/upstream-tests.fmf
+++ b/rpms/perl-Digest/tests/upstream-tests.fmf
@@ -2,3 +2,10 @@ summary: Upstream tests
 component: perl-Digest
 require: perl-Digest-tests
 test: /usr/libexec/perl-Digest/test
+enabled: true
+tag:
+  - rhel-buildroot
+adjust:
+  - enabled: false
+    when: distro < rhel-10 or distro < centos-stream-10
+    continue: false


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: perl-Digest
- **Version**: 1.20 → 1.20
- **Release**: 521
- **Upstream SHA**: `66a3c0dcfa05`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/perl-Digest.git

Automatically synced from Fedora dist-git by Factory.