### PR TITLE
Update mariadb11.8 to 11.8.6

### DIFF
--- a/metadata/mariadb11.8.json
+++ b/metadata/mariadb11.8.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
   "modification_status": "clean",
-  "release": "2",
-  "sha": "fdc27849ae7e0ea4e434d351b56bc2a3c62008c1",
+  "release": "3",
+  "sha": "2053e366a1add149e626db0ad6a171c55e4fdf5a",
   "source": "https://src.fedoraproject.org/rpms/mariadb11.8.git",
   "version": "11.8.6"
 }

--- a/rpms/mariadb11.8/mariadb11.8.spec
+++ b/rpms/mariadb11.8/mariadb11.8.spec
@@ -151,6 +151,37 @@
 %global dbdatadir        %{_localstatedir}/lib/mysql
 
 
+# Macros for extra RPM relations for the versioned packages layout
+%define conflict_with_other_streams() %{expand:\
+Provides: %{majorname}%{?1:-%{1}}-any\
+Conflicts: %{majorname}%{?1:-%{1}}-any\
+}
+
+# Add versioned virtual provides, when the RPMs real names are version-less
+# (that is, when this is the "distribution default version")
+%if %?mariadb_default
+%define versioned_virtual_provides() %{expand:\
+Provides: mariadb%{majorversion}%{?1:-%{1}} = %{sameevr}\
+}
+%define versioned_virtual_provides_arched() %{expand:\
+%versioned_virtual_provides %{**}\
+Provides: mariadb%{majorversion}%{?1:-%{1}}%{?_isa} = %{sameevr}\
+}
+%else
+%define versioned_virtual_provides() %{nil}
+%define versioned_virtual_provides_arched() %{nil}
+%endif
+
+%define virtual_conflicts_and_provides() %{expand:\
+%conflict_with_other_streams %{**}\
+%versioned_virtual_provides %{**}\
+}
+
+%define virtual_conflicts_and_provides_arched() %{expand:\
+%conflict_with_other_streams %{**}\
+%versioned_virtual_provides_arched %{**}\
+}
+# End of versioned packages layout macros
 
 # Set explicit conflicts with 'mysql' packages
 %bcond_without conflicts_mysql
@@ -160,7 +191,7 @@
 
 Name:             %{majorname}%{majorversion}
 Version:          %{package_version}
-Release:          2%{?with_debug:.debug}%{?dist}
+Release:          3%{?with_debug:.debug}%{?dist}
 Epoch:            3
 
 Summary:          A very fast and robust SQL database server
@@ -344,27 +375,7 @@ Suggests:         %{pkgname}-server%{?_isa} = %{sameevr}
 # Explicitly disallow combination mariadb + mysql-server
 %{?with_conflicts_mysql:Conflicts: mysql-server-any}
 
-%define conflict_with_other_streams() %{expand:\
-Provides: %{majorname}%{?1:-%{1}}-any\
-Conflicts: %{majorname}%{?1:-%{1}}-any\
-}
-
-# Provide also mariadbXX.XX if default
-%if %?mariadb_default
-%define mariadbXX_if_default() %{expand:\
-Provides: mariadb%{majorversion}%{?1:-%{1}} = %{sameevr}\
-Provides: mariadb%{majorversion}%{?1:-%{1}}%{?_isa} = %{sameevr}\
-}
-%else
-%define mariadbXX_if_default() %{nil}
-%endif
-
-%define virtual_conflicts_and_provides() %{expand:\
-%conflict_with_other_streams %{**}\
-%mariadbXX_if_default %{**}\
-}
-
-%virtual_conflicts_and_provides
+%virtual_conflicts_and_provides_arched
 
 %description
 MariaDB is a community developed fork from MySQL - a multi-user, multi-threaded
@@ -388,9 +399,7 @@ Summary:          Non-essential client utilities for MariaDB/MySQL applications
 Requires:         %{pkgname} = %{sameevr}
 Requires:         perl(DBI)
 
-# Only conflicts, provides would add %%{_isa} provides for noarch,
-# which is not wanted
-%conflict_with_other_streams client-utils
+%virtual_conflicts_and_provides client-utils
 
 %description      -n %{pkgname}-client-utils
 This package contains all non-essential client utilities and scripts for
@@ -404,7 +413,7 @@ subpackage, that depends on Perl.
 Summary:          The shared libraries required for MariaDB/MySQL clients
 Requires:         %{pkgname}-common = %{sameevr}
 
-%virtual_conflicts_and_provides libs
+%virtual_conflicts_and_provides_arched libs
 
 %{?with_conflicts_mysql:Conflicts: mysql-libs-any}
 
@@ -429,7 +438,7 @@ to a MariaDB/MySQL server.
 %package          -n %{pkgname}-config
 Summary:          The config files required by server and client
 
-%virtual_conflicts_and_provides config
+%virtual_conflicts_and_provides_arched config
 
 %description      -n %{pkgname}-config
 The package provides the config file my.cnf and my.cnf.d directory used by any
@@ -449,9 +458,7 @@ Requires:         mariadb-connector-c-config
 Requires:         %{_sysconfdir}/my.cnf
 %endif
 
-# Only conflicts, provides would add %%{_isa} provides for noarch,
-# which is not wanted
-%conflict_with_other_streams common
+%virtual_conflicts_and_provides common
 
 %description      -n %{pkgname}-common
 The package provides the essential shared files for any MariaDB program.
@@ -465,9 +472,7 @@ Summary:          The error messages files required by server and embedded
 BuildArch:        noarch
 Requires:         %{pkgname}-common = %{sameevr}
 
-# Only conflicts, provides would add %%{_isa} provides for noarch,
-# which is not wanted
-%conflict_with_other_streams errmsg
+%virtual_conflicts_and_provides errmsg
 
 %description      -n %{pkgname}-errmsg
 The package provides error messages files for the MariaDB daemon and the
@@ -492,7 +497,7 @@ Requires:         lsof
 # Default wsrep_sst_method
 Requires:         rsync
 
-%virtual_conflicts_and_provides server-galera
+%virtual_conflicts_and_provides_arched server-galera
 
 %description      -n %{pkgname}-server-galera
 MariaDB is a multi-user, multi-threaded SQL database server. It is a
@@ -535,7 +540,7 @@ Requires:         %{_sysconfdir}/my.cnf
 Requires:         %{_sysconfdir}/my.cnf.d
 %endif
 
-%virtual_conflicts_and_provides server
+%virtual_conflicts_and_provides_arched server
 
 # Additional SELinux rules (common for MariaDB & MySQL) shipped in a separate package
 # For cases, where we want to fix a SELinux issues in MariaDB sooner than patched selinux-policy-targeted package is released
@@ -576,7 +581,7 @@ Requires:         %{pkgname}-server%{?_isa} = %{sameevr}
 BuildRequires:    boost-devel >= 1.40.0
 BuildRequires:    Judy-devel
 
-%virtual_conflicts_and_provides oqgraph-engine
+%virtual_conflicts_and_provides_arched oqgraph-engine
 
 %description      -n %{pkgname}-oqgraph-engine
 The package provides Open Query GRAPH engine (OQGRAPH) as plugin for MariaDB
@@ -595,7 +600,7 @@ Requires:         %{pkgname}-server%{?_isa} = %{sameevr}
 # As per https://jira.mariadb.org/browse/MDEV-21450
 BuildRequires:    libxml2-devel
 
-%virtual_conflicts_and_provides connect-engine
+%virtual_conflicts_and_provides_arched connect-engine
 
 %description      -n %{pkgname}-connect-engine
 The CONNECT storage engine enables MariaDB to access external local or
@@ -612,7 +617,7 @@ Summary:          The mariabackup tool for physical online backups
 Requires:         %{pkgname}-server%{?_isa} = %{sameevr}
 BuildRequires:    libarchive-devel
 
-%virtual_conflicts_and_provides backup
+%virtual_conflicts_and_provides_arched backup
 
 %description      -n %{pkgname}-backup
 MariaDB Backup is an open source tool provided by MariaDB for performing
@@ -637,7 +642,7 @@ Requires:         %{pkgname}-server%{?_isa} = %{sameevr}
 Provides:         bundled(rocksdb)
 Conflicts:        rocksdb-tools
 
-%virtual_conflicts_and_provides rocksdb-engine
+%virtual_conflicts_and_provides_arched rocksdb-engine
 
 %description      -n %{pkgname}-rocksdb-engine
 The RocksDB storage engine is used for high performance servers on SSD drives.
@@ -656,7 +661,7 @@ Requires(post):   (libselinux-utils if selinux-policy-%{selinuxtype})
 Requires(post):   (policycoreutils if selinux-policy-%{selinuxtype})
 Requires(post):   (policycoreutils-python-utils if selinux-policy-%{selinuxtype})
 
-%virtual_conflicts_and_provides cracklib-password-check
+%virtual_conflicts_and_provides_arched cracklib-password-check
 
 %description      -n %{pkgname}-cracklib-password-check
 CrackLib is a password strength checking library. It is installed by default
@@ -673,7 +678,7 @@ Summary:          GSSAPI authentication plugin for server
 Requires:         %{pkgname}-server%{?_isa} = %{sameevr}
 BuildRequires:    krb5-devel
 
-%virtual_conflicts_and_provides gssapi-server
+%virtual_conflicts_and_provides_arched gssapi-server
 
 %description      -n %{pkgname}-gssapi-server
 GSSAPI authentication server-side plugin for MariaDB for passwordless login.
@@ -691,7 +696,7 @@ Requires(pre):    %{pkgname}-server%{?_isa} = %{sameevr}
 
 BuildRequires:    pam-devel
 
-%virtual_conflicts_and_provides pam
+%virtual_conflicts_and_provides_arched pam
 
 %description      -n %{pkgname}-pam
 PAM authentication server-side plugin for MariaDB.
@@ -706,7 +711,7 @@ Requires:         %{pkgname}-server%{?_isa} = %{sameevr}
 BuildRequires:    sphinx libsphinxclient-devel
 Requires:         sphinx libsphinxclient
 
-%virtual_conflicts_and_provides sphinx-engine
+%virtual_conflicts_and_provides_arched sphinx-engine
 
 %description      -n %{pkgname}-sphinx-engine
 The Sphinx storage engine for MariaDB.
@@ -720,7 +725,7 @@ Requires:         %{pkgname}-server%{?_isa} = %{sameevr}
 
 BuildRequires:    curl-devel
 
-%virtual_conflicts_and_provides s3-engine
+%virtual_conflicts_and_provides_arched s3-engine
 
 %description      -n %{pkgname}-s3-engine
 The S3 read only storage engine allows archiving MariaDB tables in Amazon S3,
@@ -736,9 +741,7 @@ Requires:         %{pkgname}-server = %{sameevr}
 # mysqlhotcopy needs DBI/DBD support
 Requires:         perl(DBI) perl(DBD::MariaDB)
 
-# Only conflicts, provides would add %%{_isa} provides for noarch,
-# which is not wanted
-%conflict_with_other_streams server-utils
+%virtual_conflicts_and_provides server-utils
 
 %{?with_conflicts_mysql:Conflicts: mysql-server-any}
 
@@ -758,7 +761,7 @@ Requires:         openssl-devel
 Requires:         mariadb-connector-c-devel >= 3.0
 %endif
 
-%virtual_conflicts_and_provides devel
+%virtual_conflicts_and_provides_arched devel
 
 %{?with_conflicts_mysql:Conflicts: mysql-devel-any}
 
@@ -782,7 +785,7 @@ Summary:          MariaDB as an embeddable library
 Requires:         %{pkgname}-common = %{sameevr}
 Requires:         %{pkgname}-errmsg = %{sameevr}
 
-%virtual_conflicts_and_provides embedded
+%virtual_conflicts_and_provides_arched embedded
 
 %description      -n %{pkgname}-embedded
 MariaDB is a multi-user, multi-threaded SQL database server. This
@@ -798,7 +801,7 @@ Requires:         %{pkgname}-devel%{?_isa} = %{sameevr}
 # embedded-devel should require libaio-devel (rhbz#1290517)
 Requires:         libaio-devel
 
-%virtual_conflicts_and_provides embedded-devel
+%virtual_conflicts_and_provides_arched embedded-devel
 
 %description      -n %{pkgname}-embedded-devel
 MariaDB is a multi-user, multi-threaded SQL database server.
@@ -827,7 +830,7 @@ Requires:         perl(Sys::Hostname)
 Requires:         perl(Test::More)
 Requires:         perl(Time::HiRes)
 
-%virtual_conflicts_and_provides test
+%virtual_conflicts_and_provides_arched test
 
 %{?with_conflicts_mysql:Conflicts: mysql-test-any}
 
@@ -1836,6 +1839,9 @@ fi
 %endif
 
 %changelog
+* Thu Mar 19 2026 Michal Schorm <mschorm@redhat.com> - 3:11.8.6-3
+- Bump release for package rebuild
+
 * Wed Feb 18 2026 Pavol Sloboda <psloboda@redhat.com> - 3:11.8.6-2
 - Added a fix for SIGSEGV when using skip-grant-tables
 - Resolves: RHBZ#2438390


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: mariadb11.8
- **Version**: 11.8.6 → 11.8.6
- **Release**: 3
- **Upstream SHA**: `2053e366a1ad`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/mariadb11.8.git

Automatically synced from Fedora dist-git by Factory.