### PR TITLE
Update perl-constant to 1.33

### DIFF
--- a/metadata/perl-constant.json
+++ b/metadata/perl-constant.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "522",
-  "sha": "af378359e0bd8936d70b4a011e81879bf49660f3",
+  "sha": "e9886d22b2bb14fdda0f2f538b049d84d67d0066",
   "source": "https://src.fedoraproject.org/rpms/perl-constant.git",
-  "version": "1.33",
-  "modification_status": "clean"
+  "version": "1.33"
 }

--- a/rpms/perl-constant/gating.yaml
+++ b/rpms/perl-constant/gating.yaml
@@ -1,7 +1,19 @@
+# Fedora
 --- !Policy
+id: fedora_policy
 product_versions:
   - fedora-*
-decision_context: bodhi_update_push_stable
+decision_contexts:
+  - bodhi_update_push_testing
+  - bodhi_update_push_stable
 subject_type: koji_build
 rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
+
+# RHEL
+--- !Policy
+product_versions:
+  - rhel-*
+decision_context: osci_compose_gate
+rules:
+  - !PassingTestCaseRule {test_case_name: osci.brew-build.tier0.functional}

--- a/rpms/perl-constant/plans/internal.fmf
+++ b/rpms/perl-constant/plans/internal.fmf
@@ -1,0 +1,12 @@
+summary: Private (RHEL) beakerlib tests
+enabled: false
+adjust:
+  - when: distro == rhel
+    enabled: true
+    because: private tests are accesible only within rhel pipeline
+discover:
+  - name: rhel
+    how: fmf
+    url: https://pkgs.devel.redhat.com/git/tests/perl-constant
+execute:
+    how: tmt

--- a/rpms/perl-constant/tests/upstream-tests.fmf
+++ b/rpms/perl-constant/tests/upstream-tests.fmf
@@ -2,3 +2,10 @@ summary: Upstream tests
 component: perl-constant
 require: perl-constant-tests
 test: /usr/libexec/perl-constant/test
+enabled: true
+tag:
+  - rhel-buildroot
+adjust:
+  - enabled: false
+    when: distro < rhel-10 or distro < centos-stream-10
+    continue: false


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: perl-constant
- **Version**: 1.33 → 1.33
- **Release**: 522
- **Upstream SHA**: `e9886d22b2bb`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/perl-constant.git

Automatically synced from Fedora dist-git by Factory.