### PR TITLE
Update source-highlight to 3.1.9

### DIFF
--- a/metadata/source-highlight.json
+++ b/metadata/source-highlight.json
@@ -1,8 +1,8 @@
 {
   "branch": "rawhide",
+  "modification_status": "clean",
   "release": "27",
-  "sha": "59404ea34ee0af8b432d5a5dd6ac6e3e534217d3",
+  "sha": "7ca28aee42ac18fef75608935e59f3e036702b98",
   "source": "https://src.fedoraproject.org/rpms/source-highlight.git",
-  "version": "3.1.9",
-  "modification_status": "clean"
+  "version": "3.1.9"
 }

--- a/rpms/source-highlight/gating.yaml
+++ b/rpms/source-highlight/gating.yaml
@@ -7,13 +7,8 @@ rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
 --- !Policy
 product_versions:
-  - rhel-8
+  - rhel-*
 decision_context: osci_compose_gate
 rules:
-  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.tier1.functional}
---- !Policy
-product_versions:
-  - rhel-9
-decision_context: osci_compose_gate
-rules:
-  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.tier1.functional}
+  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.gate-build-fast-lane.functional}
+  - !PassingTestCaseRule {test_case_name: baseos-ci.brew-build.gate-build-slow-lane.functional}


### PR DESCRIPTION
## Dist-Git Sync

- **Package**: source-highlight
- **Version**: 3.1.9 → 3.1.9
- **Release**: 27
- **Upstream SHA**: `7ca28aee42ac`
- **Branch**: rawhide
- **Source**: https://src.fedoraproject.org/rpms/source-highlight.git

Automatically synced from Fedora dist-git by Factory.