### PR TITLE
Fix #122: Add .gitignore entries for RPM build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,17 @@
 builds/
 __pycache__
 
+# RPM build artifacts
+*.rpm
+*.src.rpm
+rpmbuild/
+.build-*.log
+
 # Source tarballs (stored in lookaside cache, referenced via sources file)
 # Generate checksums with: sha512sum --tag <file>
 rpms/*/*.tar.gz
 rpms/*/*.tar.bz2
 rpms/*/*.tar.xz
+*.tar.gz
+*.tar.bz2
+*.tar.xz


### PR DESCRIPTION
This PR adds .gitignore entries for common RPM build artifacts as requested in #122.

## Changes
- Added *.rpm and *.src.rpm patterns
- Added rpmbuild/ directory pattern
- Added .build-*.log build log files pattern
- Added generic archive patterns (in addition to existing rpms/*/ patterns)

Fixes #122