### PR TITLE
Fix #127: Add GitHub Actions CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Welcome to Project Hummingbird
 
+[![Build RPMs](https://github.com/p5/hummingbird-rpms/actions/workflows/build-rpms.yml/badge.svg?branch=main)](https://github.com/p5/hummingbird-rpms/actions/workflows/build-rpms.yml)
+
 Project Hummingbird builds a collection of minimal, hardened, and secure container images, aiming to provide purpose-built containers with a significantly reduced attack surface. This strong focus on security combined with a highly automated update workflow results in containers with nearly zero CVEs.
 
 For more details on the project, please refer to the [Hummingbird containers Git repository](https://gitlab.com/redhat/hummingbird/containers).


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI status badge to the README.md for the build-rpms workflow, showing the status for the main branch.

## Changes

- Added CI status badge at the top of README.md
- Badge displays the build status for the main branch
- Badge links to the workflow runs page

Fixes #127