### PR TITLE
Fix #126: Add Makefile targets for common build operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,23 @@ find-missing-rpms: # This lists rpms missing in pulp that need to be published.
 .PHONY: analyze-rpms
 analyze-rpms: # This lists rpms defined in the containers repo that are not present in the rpms repo
 	+@ci/analyze-rpms.sh $(ARGS)
+
+
+.PHONY: list
+list:
+	@find rpms -maxdepth 2 -name '*.spec' -type f | sed 's|rpms/||;s|/.*||' | sort -u
+
+.PHONY: lint
+lint:
+	@find rpms -maxdepth 2 -name '*.spec' -type f -exec rpmlint {} +
+
+.PHONY: srpm
+srpm:
+ifndef PACKAGE
+	$(error PACKAGE is not set. Usage: make srpm PACKAGE=<package-name>)
+endif
+	./ci/build_rpms.sh --nocheck "$(PACKAGE)"
+
+.PHONY: clean
+clean:
+	rm -rf builds/


### PR DESCRIPTION
Resolves #126

This PR adds four new Makefile targets for common build operations:

- **`make list`** — List all packages (spec files in rpms/)
- **`make lint`** — Run rpmlint on all spec files  
- **`make srpm PACKAGE=<name>`** — Build source RPM for a specified package using the existing build_rpms.sh script
- **`make clean`** — Remove build artifacts (builds/ directory)

These targets provide convenient shortcuts for common development tasks while keeping the implementation simple as requested.