### PR TITLE
Fix #122: Add .gitignore for RPM build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,17 @@
 builds/
 __pycache__
 
+# RPM build artifacts
+*.rpm
+*.src.rpm
+rpmbuild/
+.build-*.log
+
 # Source tarballs (stored in lookaside cache, referenced via sources file)
 # Generate checksums with: sha512sum --tag <file>
 rpms/*/*.tar.gz
 rpms/*/*.tar.bz2
 rpms/*/*.tar.xz
+*.tar.gz
+*.tar.bz2
+*.tar.xz


### PR DESCRIPTION
## Summary

Adds `.gitignore` entries to ignore RPM build artifacts as requested in #122:

- `*.rpm` files
- `*.src.rpm` source RPM files  
- `rpmbuild/` directory (BUILD, BUILDROOT, RPMS, SRPMS, SOURCES)
- `.build-*.log` build log files
- `*.tar.gz`, `*.tar.bz2`, `*.tar.xz` archive files (general patterns)
- Keeps existing `rpms/*/*.tar.*` patterns for specificity

This prevents build artifacts from being accidentally committed to the repository.

Closes #122