### PR TITLE
Fix #127: Add GitHub Actions CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Welcome to Project Hummingbird
 
+[![Build RPMs](https://github.com/p5/hummingbird-rpms/actions/workflows/build-rpms.yml/badge.svg?branch=main)](https://github.com/p5/hummingbird-rpms/actions/workflows/build-rpms.yml)
+
 Project Hummingbird builds a collection of minimal, hardened, and secure container images, aiming to provide purpose-built containers with a significantly reduced attack surface. This strong focus on security combined with a highly automated update workflow results in containers with nearly zero CVEs.
 
 For more details on the project, please refer to the [Hummingbird containers Git repository](https://gitlab.com/redhat/hummingbird/containers).


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI status badge to README.md
- Badge shows the build status of the `build-rpms` workflow on the main branch
- Provides visibility into the CI/CD pipeline health

## Changes
- Added badge link at the top of README.md, right after the project title
- Badge links to the workflow runs page for easy access to build details

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)