### PR TITLE
Fix #128: Add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Makefiles require tabs
+[Makefile]
+indent_style = tab
+
+[*.mk]
+indent_style = tab
+
+# YAML files use 2-space indent
+[*.{yml,yaml}]
+indent_size = 2
+
+# Spec files use 4-space indent (already covered by default, but explicit for clarity)
+[*.spec]
+indent_size = 4


### PR DESCRIPTION
## Summary

Adds an `.editorconfig` file to ensure consistent formatting across the repository.

## Changes

- **Default settings**: UTF-8 encoding, LF line endings, 4-space indentation, trim trailing whitespace
- **Makefiles** (Makefile, *.mk): Tab indentation (as required by Make)
- **YAML files** (*.yml, *.yaml): 2-space indentation
- **Spec files** (*.spec): 4-space indentation (explicitly configured)

This will help maintain consistency across different editors and contributors.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)