### PR TITLE
Fix #137: Confirm postgresql18 naming convention

### DIFF
--- a/rpms/postgresql18/postgresql18.spec
+++ b/rpms/postgresql18/postgresql18.spec
@@ -1506,6 +1506,10 @@ make -C postgresql-setup-%{setup_version} check
 
 
 %changelog
+* Sat Mar 29 2026 Factory Bot <factory@p5.github.com> - 18.3-1
+- Package follows versioned naming convention (postgresql18)
+- Resolves: #137
+
 * Thu Feb 26 2026 Packit <hello@packit.dev> - 18.3-1
 - Update to version 18.3
 - Resolves: rhbz#2439336


### PR DESCRIPTION
## Summary
- Adds changelog entry documenting that the postgresql package correctly follows the versioned naming convention (postgresql18)
- Confirms all requirements from issue #137 are met:
  - Directory name: `postgresql18/` ✓
  - Spec file name: `postgresql18.spec` ✓  
  - Package Name field: `postgresql18` ✓

## Context
The postgresql package in this repository was already correctly structured with versioned naming. This PR adds a formal changelog entry to document compliance with the naming convention requested in #137.

Closes #137